### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /cdk
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /cli
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /lambda
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /tests
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: /agents/github-agent
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the six package manifests (5 npm workspaces, 1 pip, plus github-actions).
- Daily checks so github-brain has PRs to auto-merge.

## Test plan
- [ ] Merge
- [ ] Confirm first Dependabot PR appears
- [ ] Watch github-brain merge (patch on green CI) or flag (minor/major)