### PR TITLE
fix(cdk): bump typescript to 6.0.3 with explicit node types

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -19,7 +19,7 @@
         "aws-cdk": "^2.1118.2",
         "esbuild": "^0.28.0",
         "ts-node": "^10.9.2",
-        "typescript": "~5.7.0"
+        "typescript": "~6.0.3"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -16,7 +16,7 @@
     "aws-cdk": "^2.1118.2",
     "esbuild": "^0.28.0",
     "ts-node": "^10.9.2",
-    "typescript": "~5.7.0"
+    "typescript": "~6.0.3"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -20,7 +20,8 @@
     "outDir": "./dist",
     "rootDir": ".",
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Bumps typescript 5.7.3 → 6.0.3 in /cdk (supersedes #34)
- Adds \`\"types\": [\"node\"]\` to cdk/tsconfig.json so ts-node can compile bin/enterprise-brain.ts under TS6

## Why #34 alone fails
TypeScript 6 no longer auto-includes \`@types/node\` in the absence of an explicit \`types\` field. CI's CDK synth errors with \"Cannot find name 'process'\" in bin/enterprise-brain.ts.

## Test plan
- [x] \`npx tsc --noEmit\` passes locally in /cdk
- [ ] CI (CDK synth) green

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)